### PR TITLE
Fix missing transcript repo accessor

### DIFF
--- a/app/services/transcript.py
+++ b/app/services/transcript.py
@@ -39,6 +39,15 @@ class TranscriptService(BaseService):
         self.transcript_repo = TranscriptRepository(self.session)
         self.bucket = settings.MINIO_BUCKETS.get("transcripts", "transcripts")
 
+    def _get_transcript_repository(self) -> TranscriptRepository:
+        """Возвращает репозиторий транскриптов.
+
+        Этот метод используется в тестах для подмены репозитория моками,
+        поэтому его явное наличие упрощает тестирование и делает зависимость
+        сервисa от репозитория более явной.
+        """
+        return TranscriptRepository(self.session)
+
     async def save_transcript(
         self,
         user_id: Union[int, str, UUID],


### PR DESCRIPTION
## Summary
- add `_get_transcript_repository` to `TranscriptService` for easier mocking

## Testing
- `pytest tests/services/test_transcript_service.py::TestTranscriptServiceMethods::test_get_user_transcripts_with_mock -q` *(fails: ModuleNotFoundError: No module named 'app.database.models')*

------
https://chatgpt.com/codex/tasks/task_e_6840ec7a96248328a0c952ffccb42655