### PR TITLE
Fix nginx cert paths and update deployment docs

### DIFF
--- a/README.Docker.md
+++ b/README.Docker.md
@@ -33,6 +33,11 @@ git clone <repo-url> . # или git pull
 cp env.docker.prod.template .env.docker.prod
 nano .env.docker.prod
 
+# 3.1 Подготавливаем SSL сертификаты
+mkdir -p ssl_certificate
+cp /path/to/aibots_kz.crt ssl_certificate/
+cp /path/to/aibots.kz.key ssl_certificate/
+
 # 4. Автоматическое развертывание
 ./docker/scripts/health-check.sh
 chmod +x docker/scripts/deploy-prod.sh

--- a/docker/env-templates/README.md
+++ b/docker/env-templates/README.md
@@ -31,8 +31,8 @@ TELEGRAM_WEBHOOK_SECRET=your_production_webhook_secret_here
 FAL_WEBHOOK_SECRET=your_production_fal_webhook_secret_here
 
 # SSL сертификаты
-SSL_CERT_PATH=/etc/nginx/ssl/cert.pem
-SSL_KEY_PATH=/etc/nginx/ssl/key.pem
+SSL_CERT_PATH=/etc/nginx/ssl/aibots_kz.crt
+SSL_KEY_PATH=/etc/nginx/ssl/aibots.kz.key
 ```
 
 **Важно**: Dev шаблон уже содержит рабочие API ключи для разработки!

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -58,8 +58,8 @@ http {
         server_name aibots.kz;
 
         # SSL сертификаты
-        ssl_certificate /etc/nginx/ssl/cert.pem;
-        ssl_private_key /etc/nginx/ssl/key.pem;
+        ssl_certificate /etc/nginx/ssl/aibots_kz.crt;
+        ssl_certificate_key /etc/nginx/ssl/aibots.kz.key;
 
         # SSL настройки
         ssl_protocols TLSv1.2 TLSv1.3;

--- a/docker/scripts/deploy-prod.sh
+++ b/docker/scripts/deploy-prod.sh
@@ -39,6 +39,12 @@ if [ ! -f ".env.docker.prod" ]; then
     exit 1
 fi
 
+# Проверка SSL сертификатов
+if [ ! -f "ssl_certificate/aibots_kz.crt" ] || [ ! -f "ssl_certificate/aibots.kz.key" ]; then
+    log_error "SSL сертификаты не найдены. Поместите aibots_kz.crt и aibots.kz.key в папку ssl_certificate/"
+    exit 1
+fi
+
 log "🚀 Начинаем развертывание Aisha Bot v2 в продакшн..."
 
 # 1. Проверка внешних сервисов


### PR DESCRIPTION
## Summary
- use real SSL file names in nginx config
- mention SSL prep steps in Docker README
- document updated cert paths in env template docs
- validate presence of cert files during production deploy

## Testing
- `nginx -t -c $(pwd)/docker/nginx/nginx.conf`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_6842716daf0883288f3aa5a89f75842f